### PR TITLE
Add a regex to getImportSources

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function collectImportsSync(
   entry /*: string */,
   options /*: { extensions: Array<string> } */ = {extensions: ['js', 'jsx', 'babel']},
   parserOpts /*:: ?: ParserOptions */,
-  resolveOpts /*:: ?: ResolveOptions */,
+  resolveOpts /*:: ?: ResolveOptions */
   
 ) {
   let visited = {};

--- a/index.js
+++ b/index.js
@@ -22,26 +22,17 @@ export type ResolveOptions = {
 };
 */
 
-function getFileExtension(filename)
-{
-  var ext = /^.+\.([^.]+)$/.exec(filename);
-  return ext == null ? "" : ext[1];
-}
-
 function getImportSources(filePath, parserOpts, extensions) {
   let importSources = [];
-    if (extensions.indexOf(getFileExtension(filePath))> -1 ) {
-      let file = loadFileSync(filePath, parserOpts);
-      for (let item of file.path.get('body')) {
-        if (
-          item.isImportDeclaration() ||
-          (item.isExportDeclaration() && item.node.source)
-        ) {
-          importSources.push(item.node.source.value);
-        }
+  if (extensions.indexOf(path.extname(filePath).replace('.', ''))> -1 ) {
+    let file = loadFileSync(filePath, parserOpts);
+    for (let item of file.path.get('body')) {
+      if (item.isImportDeclaration() || (item.isExportDeclaration() && item.node.source)) {
+        importSources.push(item.node.source.value);
       }
     }
-
+  }
+  
   return importSources;
 }
 
@@ -55,7 +46,7 @@ const INTERNAL_MODULE_SOURCE = /^\./;
 
 function collectImportsSync(
   entry /*: string */,
-  options /*: { extensions: Array<string> } */ = {extensions: ['js', 'jsx', 'babel']},
+  options /*: { extensions: Array<string> } */ = { extensions: ['js', 'jsx', 'babel'] },
   parserOpts /*:: ?: ParserOptions */,
   resolveOpts /*:: ?: ResolveOptions */
   

--- a/index.js
+++ b/index.js
@@ -23,18 +23,19 @@ export type ResolveOptions = {
 */
 
 function getImportSources(filePath, parserOpts) {
-  let file = loadFileSync(filePath, parserOpts);
+  const fileReg = /^(?!\.(gif|jpg|png|ico|less|css|svg)$).*\.(gif|jpg|png|ico|less|css|svg)$/;
   let importSources = [];
-
-  for (let item of file.path.get('body')) {
-    if (
-      item.isImportDeclaration() ||
-      (item.isExportDeclaration() && item.node.source)
-    ) {
-      importSources.push(item.node.source.value);
+  if (!fileReg.test(filePath)) {
+    let file = loadFileSync(filePath, parserOpts);
+    for (let item of file.path.get('body')) {
+      if (
+        item.isImportDeclaration() ||
+        (item.isExportDeclaration() && item.node.source)
+      ) {
+        importSources.push(item.node.source.value);
+      }
     }
   }
-
   return importSources;
 }
 


### PR DESCRIPTION
Before the function was not checking for the extensions trying to transform a image files to .js
I added a regex that will check for those files.

**Questions**
- [x] Maybe it is not necessary to filter css files?
- [x] Maybe I need to add more extensions
- [x] Maybe a regex is not the best approach 